### PR TITLE
WIP: Use :main compiler option if no :require or :init-fns used

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+## Unreleased
+
+- Allow using `:main` option if neither `:require` or `:init-fns` is used in
+`.cljs.edn` file.
+    - **NOTE**: Older boot-reload and boot-cljs-repl use `:require` to add their
+    code to the build. You need to use versions `[adzerk/boot-reload "x.y.z"]`
+    and `[adzerk/boot-cljs-repl "x.y.z"]` which use `:preload` compiler option
+    if `:require` or `:init-fns` are not used.
+
 ## 1.7.228-2 (18.10.2016)
 
 **[compare](https://github.com/adzerk-oss/boot-cljs/compare/1.7.228-1...1.7.228-2)**

--- a/src/adzerk/boot_cljs/impl.clj
+++ b/src/adzerk/boot_cljs/impl.clj
@@ -87,7 +87,7 @@
                                               :type warning-type})))))]
     (try
       (build
-        (inputs input-path)
+        (apply inputs input-path dirs)
         (assoc opts :warning-handlers [handler])
         stored-env)
       {:warnings  @warnings


### PR DESCRIPTION
Fixes #139 

I would like to support using normal ClojureScript compiler-options without Boot-cljs overwriting user provided options. I also don't want to break existing setups.

Proposed logic:

1. `:main` compiler-option provided and no `:require` and no `:init-fns` -> `:main` is used and Boot-cljs doesn't generate shim namespace
2. `:main` compiler-option provided and `:require` or `:init-fns` provided -> `:main` is ignored, shim namespace generated and warning is printed
3. no `:main` -> shim namespace is generated

There is one problem.

Boot-reload and Boot-cljs-repl use `:require` to add their client code automatically to the build.

It is possible to update both tasks to use `:preloads` instead, if they detect that condition **1** is true (https://github.com/adzerk-oss/boot-reload/tree/feature/preloads-instead-require, https://github.com/adzerk-oss/boot-cljs-repl/tree/feature/preloads-instead-require).

There is however one side-effect of using `:preloads` to load Boot-reload code.

Currently Boot-reload client namespace is loaded just after application code, and after any dependencies (Reagent etc.) are loaded. Preload namespaces however are loaded as early as possible, after dependencies of preload namespaces are loaded.

Boot-reload [changes the load mechanims Closure uses](https://github.com/adzerk-oss/boot-reload/blob/master/src/adzerk/boot_reload/client.cljs#L17), and the current version is broken if enabled during initial page load. This can be [fixed](https://github.com/adzerk-oss/boot-reload/pull/108) but this fix has a side-effect that the initial page-load will be slower as files are not being loaded parallel.