### PR TITLE
use the output path as the asset path

### DIFF
--- a/src/adzerk/boot_cljs/middleware.clj
+++ b/src/adzerk/boot_cljs/middleware.clj
@@ -56,7 +56,7 @@
   foo.bar CLJS namespace with output to foo/bar.js)."
   [{:keys [tmp-src tmp-out main] :as ctx} write-main?]
   (let [out-rel-path (cljs-edn-path->output-dir-path (:rel-path main))
-        asset-path   (util/get-name out-rel-path)
+        asset-path   out-rel-path
         out-file     (io/file tmp-out out-rel-path)
         out-path     (.getPath out-file)
         js-path      (util/path tmp-out (cljs-edn-path->js-path (:rel-path main)))


### PR DESCRIPTION
I am new to this project, but I ran into this issue when playing around with `boot-cljs`. (#152)

If I put my `.cljs.edn` file at `/js/main.cljs.edn`, then my compiled output goes to `/js/main.out/`, but when I actually load the resulting javascript in my page, I get errors that it can't find files in `/main.out/`. The `js` prefix is lost because `util/get-name` is called on the relative output path, which just calls `File.getName`

I figured this would be a good solution... which is to use the relative `output-dir` as the `asset-path`.

What do you think?