### PR TITLE
Allow CLJS v1.9.518+ to compile with npm-deps

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -4,7 +4,7 @@
   :dependencies   '[[org.clojure/clojure "1.8.0" :scope "provided"]
                     [adzerk/boot-test          "1.1.0"  :scope "test"]
                     [pandeiro/boot-http        "0.7.0"  :scope "test"]
-                    [org.clojure/clojurescript "1.7.228" :scope "test"]
+                    [org.clojure/clojurescript "1.9.518" :scope "test"]
                     [ns-tracker "0.3.1" :scope "test"]])
 
 (require '[adzerk.boot-test]

--- a/src/adzerk/boot_cljs.clj
+++ b/src/adzerk/boot_cljs.clj
@@ -238,7 +238,8 @@
   [i ids IDS               #{str} ""
    O optimizations LEVEL   kw   "The optimization level."
    s source-map            bool "Create source maps for compiled JS."
-   c compiler-options OPTS edn  "Options to pass to the Clojurescript compiler."]
+   c compiler-options OPTS edn  "Options to pass to the Clojurescript compiler."
+   n npm-deps DEPS         edn  "Dependencies to pass to the Clojurescript compiler"]
 
   (let [tmp-result (core/tmp-dir!)
         compilers  (atom {})

--- a/src/adzerk/boot_cljs/middleware.clj
+++ b/src/adzerk/boot_cljs/middleware.clj
@@ -42,7 +42,7 @@
    {:keys [compiler-options] :as task-options}]
   (assoc ctx :opts (merge (:compiler-options main)
                           compiler-options
-                          (select-keys task-options [:optimizations :source-map]))))
+                          (select-keys task-options [:optimizations :source-map :npm-deps]))))
 
 (defn set-option [ctx k value]
   (when-let [current-value (get-in ctx [:opts k])]

--- a/test/adzerk/boot_cljs_test.clj
+++ b/test/adzerk/boot_cljs_test.clj
@@ -24,3 +24,7 @@
 (deftest a-test
   (testing "Compiling with .cljs.edn"
     (is (= "test passed" (hunit-page "/demo/index.html")))))
+
+(deftest npm-test
+  (testing "Includes npm modules when present"
+    (is (= "test passed 00042" (hunit-page "/demo/other.html")))))

--- a/test/demo/other.cljs
+++ b/test/demo/other.cljs
@@ -1,3 +1,7 @@
-(ns demo.other)
+(ns demo.other
+  (:require left-pad))
+
+(let [result (str "test passed " (left-pad 42 5 0))]
+  (.appendChild (.-body js/document) (.createTextNode js/document result)))
 
 (.appendChild (.-body js/document) (.createTextNode js/document "test passed"))

--- a/test/demo/other.cljs
+++ b/test/demo/other.cljs
@@ -3,5 +3,3 @@
 
 (let [result (str "test passed " (left-pad 42 5 0))]
   (.appendChild (.-body js/document) (.createTextNode js/document result)))
-
-(.appendChild (.-body js/document) (.createTextNode js/document "test passed"))

--- a/test/demo/other.cljs.edn
+++ b/test/demo/other.cljs.edn
@@ -1,1 +1,2 @@
-{:require [demo.other]}
+{:require [demo.other]
+ :compiler-options {:npm-deps {:left-pad "1.1.3"}}}


### PR DESCRIPTION
ClojureScript 1.9.518 [provides a new `:npm-deps` option](https://anmonteiro.com/2017/03/requiring-node-js-modules-from-clojurescript-namespaces/) to pull in node modules as CLJS namespaces. This PR passes those options along to `clojurescript.build.api/build` when provided.