### PR TITLE
Wrap :main value in symbol

### DIFF
--- a/src/adzerk/boot_cljs/middleware.clj
+++ b/src/adzerk/boot_cljs/middleware.clj
@@ -73,7 +73,7 @@
         ;; We set out own shim ns as :main, but if user provides :main,
         ;; include that in our shim ns requires
         requires     (if-let [main (:main (:opts ctx))]
-                       (conj requires main)
+                       (conj requires (symbol main))
                        requires)
         init-nss     (into requires (->> init-fns (keep namespace) (map symbol)))]
     (.mkdirs out-file)


### PR DESCRIPTION
This avoids triggering a ClassCastException when trying to use values from the
requires sorted set: string :main is a valid value and will always be
converted.